### PR TITLE
change titles to appear as hyperlinks

### DIFF
--- a/src/summarize.py
+++ b/src/summarize.py
@@ -88,8 +88,7 @@ def compose_prompt(story, story_text, truncated=False):
 
 def compose_message(story, summary_text, percentage_used):
     # compose the message that will be sent to the channel
-    message =  f"*{story.title}*\n"
-    message += f"https://news.ycombinator.com/item?id={story.id}\n"
+    message =  f"[{story.title}](https://news.ycombinator.com/item?id={story.id})\n"
     summary_text = summary_text.lstrip()
     if summary_text:
         message += summary_text
@@ -98,8 +97,6 @@ def compose_message(story, summary_text, percentage_used):
     if percentage_used < 100:
         message += f" (Summary based on {percentage_used}% of story text.)"
     return message
-
-
 
 
 def extract_text_from_html(content):

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -22,7 +22,7 @@ def send_message(text):
     async def send():
         chat = await bot.get_chat(TELEGRAM_CHANNEL_ID)
         # only send first 4096 bytes to avoid overruning telegram max message size
-        await chat.send_message(text=text[:4096], parse_mode=ParseMode.MARKDOWN)
+        await chat.send_message(text=text[:4096], parse_mode=ParseMode.MARKDOWN_V2)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(send())
 


### PR DESCRIPTION
* changes titles to appear as hyperlinks in the telegram channel.
* updates `ParseMode.MARKDOWN` to `ParseMode.MARKDOWN_V2` since according to [telegram-bot docs](https://docs.python-telegram-bot.org/en/stable/telegram.parsemode.html):
  > [MARKDOWN](https://docs.python-telegram-bot.org/en/stable/telegram.parsemode.html#telegram.ParseMode.MARKDOWN) is a legacy mode, retained by Telegram for backward compatibility. You should use [MARKDOWN_V2](https://docs.python-telegram-bot.org/en/stable/telegram.parsemode.html#telegram.ParseMode.MARKDOWN_V2) instead.